### PR TITLE
Two minor fixes for kakoune support

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -760,10 +760,10 @@ documents.onDidChangeContent(async (change) => {
 });
 
 const clearWorkspaceDiagnostics = async (context: ContextAware) => {
-  context.getContextFiles().forEach((uri) => {
+  context.getContextFiles().forEach((file) => {
     connection.sendDiagnostics({
-      uri,
-      version: documents.get(`file://${uri}`)?.version,
+      uri: `file://${file}`,
+      version: documents.get(`file://${file}`)?.version,
       diagnostics: [],
     } satisfies PublishDiagnosticsParams);
   });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -201,6 +201,7 @@ const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 
 let hasConfigurationCapability = true;
 let hasWorkspaceFolderCapability = false;
+let hasDiagnosticRefreshCapability = false;
 
 connection.onInitialize((params: InitializeParams) => {
   const capabilities = params.capabilities;
@@ -213,6 +214,7 @@ connection.onInitialize((params: InitializeParams) => {
   hasWorkspaceFolderCapability = !!(
     capabilities.workspace && !!capabilities.workspace.workspaceFolders
   );
+  hasDiagnosticRefreshCapability = !!(capabilities.workspace?.diagnostics?.refreshSupport)
 
   const result: InitializeResult = {
     capabilities: {
@@ -411,7 +413,9 @@ connection.onDidChangeConfiguration((change) => {
     updateActiveContext(activeFileUri, true);
   }
 
-  connection.languages.diagnostics.refresh();
+  if (hasDiagnosticRefreshCapability) {
+    connection.languages.diagnostics.refresh()
+  }
 });
 
 const resolveGlobal = () => {


### PR DESCRIPTION
Hi - thank you so much for this project, it is exactly what i was looking for.

In integrating it in kakoune, i had two minor issues.

The first was an invalid uri.

The second was dts-lsp crashing when it received a methodNotImplemented error from kakoune on diagnostics.refresh(). I added a capability check for it. The only other solution i could see would be to update vscode-languageserver to get https://github.com/microsoft/vscode-languageserver-node/pull/1442, where the error could be handled.

And for anyone interested, here is the config i use to run it in kakoune.
```

hook -group lsp-project-zephyr global BufSetOption filetype=(devicetree) %{
   eval %sh{
      root=$(eval "$kak_opt_lsp_find_root" .build_info.yml $(: kak_buffile))
      [ -e "$root/.build_info.yml" ] || exit 0

      settings=$(cat ".build_info.yml" | yq -c '{ "defaultIncludePaths": .cmake.devicetree."include-dirs", "contexts": [{ "bindingType": "Zephyr", "zephyrBindings": .cmake.devicetree."bindings-dirs", "includePaths": .cmake.devicetree."include-dirs", "dtsFile": .cmake.devicetree.files[0], "overlays": .cmake.devicetree.files[1:] }], "preferredContext": 0 } | { devicetree: {settings: {"_": {devicetree: .}}}}' | yj -jt | sed '/^\[devicetree\]$/d')

      cat <<EOF
      set-option buffer lsp_servers %{
         [devicetree]
         root = '$root'
         command = "npm"
         args = ["x", "--", "devicetree-language-server", "--stdio"]
         # command = "node"
         # args = ["/home/topisani/git/dts-lsp/server/dist/server.js", "--stdio"]
         settings_section = "_"

      $settings
      }
EOF
   }
}
```
I manually run `ln -s {build_dir}/build_info.yml .build_info.yml` whenever i change build directories, and then the above uses yq to generate the settings from the build_info.yml file. 
I believe this functionality could be moved into dts-lsp to fully auto detect build variables.

Thanks again for the project, its been a big improvement to my workflow already!