### PR TITLE
Only send workspaceFolders request if client sets capability

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -442,7 +442,11 @@ const getResolvedAllContextSettings = async () => {
 };
 
 const getWorkspaces = async () => {
-	return (await connection.workspace.getWorkspaceFolders()) ?? [];
+	if (hasWorkspaceFolderCapability) {
+		return (await connection.workspace.getWorkspaceFolders()) ?? [];
+	} else {
+		return [];
+	}
 };
 
 const createContext = async (context: ResolvedContext) => {


### PR DESCRIPTION
Fixes crash with the kakoune kak-lsp client that does not support workspacefolders.