### PR TITLE
Fix formatter corrupting files that use multi-line macros

### DIFF
--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -738,19 +738,21 @@ async function baseFormatAstBaseItems(
 
 	const result: FileDiagnostic[] = (
 		await Promise.all(
-			astItems.flatMap(
-				async (base) =>
-					await getTextEdit(
-						documentFormattingParams,
-						base,
-						fsPath,
-						astItemLevel,
-						splitDocument,
-						includes,
-						ifDefBlocks,
-						options,
-					),
-			),
+			astItems
+				.filter((base) => isPathEqual(base.fsPath, fsPath))
+				.flatMap(
+					async (base) =>
+						await getTextEdit(
+							documentFormattingParams,
+							base,
+							fsPath,
+							astItemLevel,
+							splitDocument,
+							includes,
+							ifDefBlocks,
+							options,
+						),
+				),
 		)
 	).flat();
 

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -54,6 +54,7 @@ import {
 	fileURIToFsPath,
 	genFormattingDiagnostic,
 	isPathEqual,
+	isVirtualFsPath,
 	rangesOverlap,
 	toPosition,
 	toRange,
@@ -741,8 +742,8 @@ async function baseFormatAstBaseItems(
 			astItems
 				.filter((base) => isPathEqual(base.fsPath, fsPath))
 				.flatMap(
-					async (base) =>
-						await getTextEdit(
+					async (base) => {
+						return await getTextEdit(
 							documentFormattingParams,
 							base,
 							fsPath,
@@ -751,7 +752,8 @@ async function baseFormatAstBaseItems(
 							includes,
 							ifDefBlocks,
 							options,
-						),
+						);
+					},
 				),
 		)
 	).flat();
@@ -1282,19 +1284,21 @@ const formatDtcNode = async (
 	result.push(
 		...(
 			await Promise.all(
-				node.children.flatMap((c) =>
-					getTextEdit(
-						documentFormattingParams,
-						c,
-						fsPath,
-						computeLevel,
-						documentText,
-						includes,
-						ifDefBlocks,
-						options,
-						level + 1,
+				node.children
+					.filter((c) => isPathEqual(c.fsPath, fsPath))
+					.flatMap((c) =>
+						getTextEdit(
+							documentFormattingParams,
+							c,
+							fsPath,
+							computeLevel,
+							documentText,
+							includes,
+							ifDefBlocks,
+							options,
+							level + 1,
+						),
 					),
-				),
 			)
 		).flat(),
 	);
@@ -1339,6 +1343,8 @@ const formatLabeledValue = <T extends ASTBase>(
 	openBracket: Token | undefined,
 	documentText: string[],
 ): FileDiagnostic[] => {
+	if (isVirtualFsPath(value.firstToken.fsPath)) return [];
+
 	const result: FileDiagnostic[] = [];
 
 	result.push(
@@ -1475,7 +1481,7 @@ const formatValue = (
 				),
 			);
 
-			if (value.closeBracket?.prevToken) {
+			if (value.closeBracket?.prevToken && !isVirtualFsPath(value.closeBracket.prevToken.fsPath)) {
 				if (
 					value.values.at(-1)?.lastToken ===
 						value.closeBracket?.prevToken ||

--- a/server/src/formatting/indentExpressions.ts
+++ b/server/src/formatting/indentExpressions.ts
@@ -24,7 +24,7 @@ import { PropertyValues } from '../ast/dtc/values/values';
 import { PropertyValue } from '../ast/dtc/values/value';
 import { ArrayValues } from '../ast/dtc/values/arrayValue';
 import { ByteStringValue } from '../ast/dtc/values/byteString';
-import { applyEdits, genFormattingDiagnostic } from '../helpers';
+import { applyEdits, genFormattingDiagnostic, isPathEqual } from '../helpers';
 import {
 	ComplexExpression,
 	Expression,
@@ -115,17 +115,19 @@ async function baseIndentExpression(
 
 	const result: FileDiagnostic[] = (
 		await Promise.all(
-			astItems.flatMap(
-				async (base) =>
-					await indentExpressionEdits(
-						documentFormattingParams,
-						documentText,
-						base,
-						fsPath,
-						astItemLevel,
-						options,
-					),
-			),
+			astItems
+				.filter((base) => isPathEqual(base.fsPath, fsPath))
+				.flatMap(
+					async (base) =>
+						await indentExpressionEdits(
+							documentFormattingParams,
+							documentText,
+							base,
+							fsPath,
+							astItemLevel,
+							options,
+						),
+				),
 		)
 	).flat();
 

--- a/server/src/formatting/longLines.ts
+++ b/server/src/formatting/longLines.ts
@@ -27,6 +27,7 @@ import { ByteStringValue } from '../ast/dtc/values/byteString';
 import {
 	applyEdits,
 	genFormattingDiagnostic,
+	isPathEqual,
 	sameLine,
 	toPosition,
 } from '../helpers';
@@ -160,17 +161,19 @@ async function baseLongLineItems(
 
 	const result: FileDiagnostic[] = (
 		await Promise.all(
-			astItems.flatMap(
-				async (base) =>
-					await getWrapLineEdit(
-						documentFormattingParams,
-						base,
-						fsPath,
-						astItemLevel,
-						splitDocument,
-						options,
-					),
-			),
+			astItems
+				.filter((base) => isPathEqual(base.fsPath, fsPath))
+				.flatMap(
+					async (base) =>
+						await getWrapLineEdit(
+							documentFormattingParams,
+							base,
+							fsPath,
+							astItemLevel,
+							splitDocument,
+							options,
+						),
+				),
 		)
 	).flat();
 


### PR DESCRIPTION
When a function-like macro expands to DTS nodes, the parser injects the expanded tokens into the stream with a virtual fsPath and positions starting at line 0. Without a path guard, baseFormatAstBaseItems and baseLongLineItems process these nodes and emit edits targeting line 0 of the original file, producing garbage.

This fixes this by filtering allAstItems to the current file's fsPath before dispatch, mirroring the guard already present in formatDtcInclude. This covers formatDtcNode, formatDtcProperty, and formatDtcDelete in one place, and applies the same filter to the long-line wrapping pass.

This fixes #131 and https://github.com/kylebonnici/dts-linter/issues/9