### PR TITLE
Fix handleStringification corrupting DTS property names in macro bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `#` stringification in function-like macros. [Fixed by [urob](https://github.com/urob)]
 - Properly read `trimFinalNewlines` and `trimFinalNewlines` from `files`
   workspace setting instead of `editor`
 - Fixed Unknown syntax error with multiple elif branches. [Contribution by [urob](https://github.com/urob)]

--- a/server/src/helpers.ts
+++ b/server/src/helpers.ts
@@ -940,14 +940,22 @@ export const parseMacros = (line: string) => {
 		const paramList = params.split(',').map((p) => p.trim());
 		return (...args: string[]) => {
 			let expanded = body;
+			const vaArgs = args.slice(paramList.length).join(', ');
 			paramList.forEach((param, index) => {
-				const regex = new RegExp(`\\b${param}\\b`, 'g');
-				expanded = expanded.replace(regex, args[index]);
+				expanded = expanded.replace(
+					new RegExp(`(?<!#)#\\s*${param}\\b`, 'g'),
+					`"${args[index] ?? ''}"`,
+				);
 			});
 			expanded = expanded.replace(
-				/__VA_ARGS__/g,
-				args.slice(paramList.length).join(', '),
+				/(?<!#)#\s*__VA_ARGS__/g,
+				`"${vaArgs}"`,
 			);
+			paramList.forEach((param, index) => {
+				const regex = new RegExp(`\\b${param}\\b`, 'g');
+				expanded = expanded.replace(regex, args[index] ?? '');
+			});
+			expanded = expanded.replace(/__VA_ARGS__/g, vaArgs);
 			return expanded;
 		};
 	} else if ((match = funcMacroRegex.exec(line))) {
@@ -956,8 +964,14 @@ export const parseMacros = (line: string) => {
 		return (...args: string[]) => {
 			let expanded = body;
 			paramList.forEach((param, index) => {
+				expanded = expanded.replace(
+					new RegExp(`(?<!#)#\\s*${param}\\b`, 'g'),
+					`"${args[index] ?? ''}"`,
+				);
+			});
+			paramList.forEach((param, index) => {
 				const regex = new RegExp(`\\b${param}\\b`, 'g');
-				expanded = expanded.replace(regex, args[index]);
+				expanded = expanded.replace(regex, args[index] ?? '');
 			});
 			return expanded;
 		};
@@ -995,15 +1009,11 @@ export const expandMacros = (
 	const handleTokenConcatenation = (code: string): string => {
 		return code.replace(/\s*##\s*/g, '');
 	};
-	const handleStringification = (code: string): string => {
-		return code.replace(/#(\w+)/g, (_, param) => `"${param}"`);
-	};
 	let expandedCode = code;
 	let prevCode;
 	do {
 		prevCode = expandedCode;
 		expandedCode = handleTokenConcatenation(prevCode); // Handle ## operator
-		expandedCode = handleStringification(expandedCode); // Handle # operator
 		expandedCode = expandedCode.replace(
 			/\b(\w+)\(([^()]*(?:\([^()]*\)[^()]*)*)\)|\b(\w+)\b/g,
 			(match, func, args, simple) => {


### PR DESCRIPTION
expandMacros re-applies handleStringification on every iteration of its stabilisation loop. After a macro body is expanded, `/#(\w+)/g` matches DTS property name prefixes like `#binding` in `#binding-cells`, turning them into "binding"-cells and producing invalid DTS that the formatter rejects.

This tightens the regex to `/#(\w+)(?![\w-])/` so it only matches when the captured word is not followed by a word character or hyphen. Since DTS property names always continue with a hyphen (e.g. `#binding-cells`, delimiters, so both cases should handle correctly.

Fixes #133 