### PR TITLE
Fix Unknown syntax error with multiple elif branches

### DIFF
--- a/server/src/ast/cPreprocessors/ifDefine.ts
+++ b/server/src/ast/cPreprocessors/ifDefine.ts
@@ -98,6 +98,7 @@ export class IfDefineBlock extends ASTBase {
 		public readonly ifDef: CIfDef | CIfNotDef,
 		public readonly endIf: CEndIf | null,
 		public readonly elseOption?: CElse,
+		private readonly hasMultipleElseif: boolean = false,
 	) {
 		super();
 		this.addChild(ifDef);
@@ -176,7 +177,14 @@ export class IfDefineBlock extends ASTBase {
 				this.elseOption.keyword.lastToken,
 			).forEach((t) => invalidRange.add(t));
 
-			if (useMainBlock && this.elseOption.content) {
+			// Mark elseContent invalid when the main block is active, or when
+			// there are multiple elif branches (hasMultipleElseif=true). In the
+			// latter case the elseContent spans multiple elif bodies and their
+			// separator keywords via the linked-list walk; we can't evaluate which
+			// elif condition is true, so we suppress the entire range to prevent
+			// "Unknown syntax" from intermediate #elif/#else tokens leaking to the
+			// DTS parser.
+			if ((useMainBlock || this.hasMultipleElseif) && this.elseOption.content) {
 				getRangeTokens(
 					this.elseOption.content.firstToken,
 					this.elseOption.content.lastToken,

--- a/server/src/ast/cPreprocessors/ifDefine.ts
+++ b/server/src/ast/cPreprocessors/ifDefine.ts
@@ -98,7 +98,7 @@ export class IfDefineBlock extends ASTBase {
 		public readonly ifDef: CIfDef | CIfNotDef,
 		public readonly endIf: CEndIf | null,
 		public readonly elseOption?: CElse,
-		private readonly hasMultipleElseif: boolean = false,
+		private readonly hasMultipleSeparators: boolean = false,
 	) {
 		super();
 		this.addChild(ifDef);
@@ -178,13 +178,12 @@ export class IfDefineBlock extends ASTBase {
 			).forEach((t) => invalidRange.add(t));
 
 			// Mark elseContent invalid when the main block is active, or when
-			// there are multiple elif branches (hasMultipleElseif=true). In the
-			// latter case the elseContent spans multiple elif bodies and their
+			// there are multiple separator tokens (hasMultipleSeparators=true). In
+			// the latter case elseContent spans multiple elif/else bodies and their
 			// separator keywords via the linked-list walk; we can't evaluate which
-			// elif condition is true, so we suppress the entire range to prevent
-			// "Unknown syntax" from intermediate #elif/#else tokens leaking to the
-			// DTS parser.
-			if ((useMainBlock || this.hasMultipleElseif) && this.elseOption.content) {
+			// condition is true, so we suppress the entire range to prevent
+			// "Unknown syntax" from intermediate tokens leaking to the DTS parser.
+			if ((useMainBlock || this.hasMultipleSeparators) && this.elseOption.content) {
 				getRangeTokens(
 					this.elseOption.content.firstToken,
 					this.elseOption.content.lastToken,

--- a/server/src/cPreprocessorParser.ts
+++ b/server/src/cPreprocessorParser.ts
@@ -608,17 +608,27 @@ export class CPreprocessorParser extends BaseParser {
 		);
 
 		let cElse: CElse | undefined;
+		const hasMultipleElseif = block.separatorTokens.length > 1;
 
 		if (block.splitTokens.length > 1) {
 			const elseToken = block.separatorTokens[0];
 			const elseKeyword = new Keyword(createTokenIndex(elseToken));
 			let elseContent: CPreprocessorContent | undefined;
-			if (block.splitTokens[1].tokens.length) {
+			// Span ALL remaining elif/else branches, not just the first one.
+			// getRangeTokens walks nextToken links, so spanning to the last token
+			// automatically includes intermediate #elif/#else separator tokens.
+			const firstContentToken = block.splitTokens[1].tokens[0];
+			let lastContentToken: Token | undefined;
+			for (let i = block.splitTokens.length - 1; i >= 1; i--) {
+				lastContentToken = block.splitTokens[i].tokens.at(-1);
+				if (lastContentToken) break;
+			}
+			if (!lastContentToken && block.separatorTokens.length > 1) {
+				lastContentToken = block.separatorTokens.at(-1);
+			}
+			if (firstContentToken && lastContentToken) {
 				elseContent = new CPreprocessorContent(
-					createTokenIndex(
-						block.splitTokens[1].tokens[0],
-						block.splitTokens[1].tokens.at(-1),
-					),
+					createTokenIndex(firstContentToken, lastContentToken),
 				);
 			}
 			cElse = new CElse(elseKeyword, elseContent ?? null);
@@ -642,6 +652,7 @@ export class CPreprocessorParser extends BaseParser {
 			ifDef,
 			endifKeyword ?? null,
 			cElse,
+			hasMultipleElseif,
 		);
 
 		this.mergeStack();

--- a/server/src/cPreprocessorParser.ts
+++ b/server/src/cPreprocessorParser.ts
@@ -608,7 +608,7 @@ export class CPreprocessorParser extends BaseParser {
 		);
 
 		let cElse: CElse | undefined;
-		const hasMultipleElseif = block.separatorTokens.length > 1;
+		const hasMultipleSeparators = block.separatorTokens.length > 1;
 
 		if (block.splitTokens.length > 1) {
 			const elseToken = block.separatorTokens[0];
@@ -617,7 +617,13 @@ export class CPreprocessorParser extends BaseParser {
 			// Span ALL remaining elif/else branches, not just the first one.
 			// getRangeTokens walks nextToken links, so spanning to the last token
 			// automatically includes intermediate #elif/#else separator tokens.
-			const firstContentToken = block.splitTokens[1].tokens[0];
+			// If a branch body is empty, fall back to the next separator token so
+			// that subsequent non-empty branches are still included in the range.
+			let firstContentToken: Token | undefined;
+			for (let i = 1; i < block.splitTokens.length && !firstContentToken; i++) {
+				firstContentToken =
+					block.splitTokens[i].tokens[0] ?? block.separatorTokens[i];
+			}
 			let lastContentToken: Token | undefined;
 			for (let i = block.splitTokens.length - 1; i >= 1; i--) {
 				lastContentToken = block.splitTokens[i].tokens.at(-1);
@@ -652,7 +658,7 @@ export class CPreprocessorParser extends BaseParser {
 			ifDef,
 			endifKeyword ?? null,
 			cElse,
-			hasMultipleElseif,
+			hasMultipleSeparators,
 		);
 
 		this.mergeStack();


### PR DESCRIPTION
This fixes #135 

The issue is caused because `processIfDefBlock` creates a single `CElse` AST node for the else/elif branch, spanning all remaining branches. This could leads to leakage of intermediate elif content into the DTS parser as unrecognized tokens. 

This adds a `hasMultipleElseif` bool to `IfDefineBlock`, which invalidates the else content regardless of which branch is active. 


