### PR TITLE
Fix: skip formatting virtual documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Properly read `trimFinalNewlines` and `trimFinalNewlines` from `files`
   workspace setting instead of `editor`
-- Fixed Unknown syntax error with multiple elif branches.
+- Fixed Unknown syntax error with multiple elif branches. [Contribution by [urob](https://github.com/urob)]
 - Diagnostics linked to virtual documents now point to the macro that
   generated the code.
+- Fixed showing and applying formatting issue from virtual documents. [Contribution by [urob](https://github.com/urob)]
 
 ### Security
 

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -49,7 +49,7 @@ import { ByteStringValue } from '../ast/dtc/values/byteString';
 import { LabeledValue } from '../ast/dtc/values/labeledValue';
 import { Include } from '../ast/cPreprocessors/include';
 import {
-	applyEdits,
+	applyFileDiagnosticEdits,
 	coreSyntaxIssuesFilter,
 	fileURIToFsPath,
 	genFormattingDiagnostic,
@@ -503,7 +503,7 @@ export async function formatText(
 		);
 	}
 
-	return diagnostic;
+	return diagnostic.filter((i) => !i.raw.virtual);
 }
 
 const getDisabledMarcoRangeEdits = async (
@@ -685,9 +685,9 @@ async function formatAstBaseItems(
 		edits,
 	);
 
-	newText = applyEdits(
+	newText = applyFileDiagnosticEdits(
 		TextDocument.create(fsPath, 'devicetree', 0, text),
-		rangeEdits.flatMap((i) => i.raw.edit).filter((e) => !!e),
+		rangeEdits,
 	);
 
 	switch (returnType) {

--- a/server/src/formatting/indentExpressions.ts
+++ b/server/src/formatting/indentExpressions.ts
@@ -24,7 +24,7 @@ import { PropertyValues } from '../ast/dtc/values/values';
 import { PropertyValue } from '../ast/dtc/values/value';
 import { ArrayValues } from '../ast/dtc/values/arrayValue';
 import { ByteStringValue } from '../ast/dtc/values/byteString';
-import { applyEdits, genFormattingDiagnostic } from '../helpers';
+import { applyFileDiagnosticEdits, genFormattingDiagnostic } from '../helpers';
 import {
 	ComplexExpression,
 	Expression,
@@ -91,9 +91,9 @@ export async function formatExpressionIndentation(
 		edits,
 	);
 
-	newText = applyEdits(
+	newText = applyFileDiagnosticEdits(
 		TextDocument.create(fsPath, 'devicetree', 0, text),
-		rangeEdits.flatMap((i) => i.raw.edit).filter((e) => !!e),
+		rangeEdits,
 	);
 
 	switch (returnType) {

--- a/server/src/formatting/longLines.ts
+++ b/server/src/formatting/longLines.ts
@@ -25,7 +25,7 @@ import { PropertyValue } from '../ast/dtc/values/value';
 import { ArrayValues } from '../ast/dtc/values/arrayValue';
 import { ByteStringValue } from '../ast/dtc/values/byteString';
 import {
-	applyEdits,
+	applyFileDiagnosticEdits,
 	genFormattingDiagnostic,
 	sameLine,
 	toPosition,
@@ -136,9 +136,9 @@ export async function formatLongLines(
 		edits,
 	);
 
-	newText = applyEdits(
+	newText = applyFileDiagnosticEdits(
 		TextDocument.create(fsPath, 'devicetree', 0, text),
-		rangeEdits.flatMap((i) => i.raw.edit).filter((e) => !!e),
+		rangeEdits,
 	);
 
 	switch (returnType) {

--- a/server/src/formatting/removeDuplicateProperties.ts
+++ b/server/src/formatting/removeDuplicateProperties.ts
@@ -21,7 +21,7 @@ import { DtcProperty } from '../ast/dtc/property';
 import { ASTBase } from '../ast/base';
 import { FileDiagnostic, FormattingIssues } from '../types';
 import {
-	applyEdits,
+	applyFileDiagnosticEdits,
 	genFormattingDiagnostic,
 	toPosition,
 	toRangeWithTokenIndex,
@@ -72,9 +72,9 @@ export async function removeDuplicateProperties(
 		edits,
 	);
 
-	newText = applyEdits(
+	newText = applyFileDiagnosticEdits(
 		TextDocument.create(fsPath, 'devicetree', 0, text),
-		rangeEdits.flatMap((i) => i.raw.edit).filter((e) => !!e),
+		rangeEdits,
 	);
 
 	switch (returnType) {

--- a/server/src/formatting/removeEmptyNodes.ts
+++ b/server/src/formatting/removeEmptyNodes.ts
@@ -19,7 +19,7 @@ import { TextEdit } from 'vscode-languageserver';
 import { ASTBase } from '../ast/base';
 import { FileDiagnostic, FormattingIssues } from '../types';
 import {
-	applyEdits,
+	applyFileDiagnosticEdits,
 	genFormattingDiagnostic,
 	toPosition,
 	toRangeWithTokenIndex,
@@ -67,9 +67,9 @@ export async function formatEmptyReferences(
 		edits,
 	);
 
-	newText = applyEdits(
+	newText = applyFileDiagnosticEdits(
 		TextDocument.create(fsPath, 'devicetree', 0, text),
-		rangeEdits.flatMap((i) => i.raw.edit).filter((e) => !!e),
+		rangeEdits,
 	);
 
 	switch (returnType) {

--- a/server/src/formatting/sortNodesAndProperties.ts
+++ b/server/src/formatting/sortNodesAndProperties.ts
@@ -20,7 +20,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { ASTBase } from '../ast/base';
 import { FileDiagnostic, FormattingIssues } from '../types';
 import {
-	applyEdits,
+	applyFileDiagnosticEdits,
 	compareWords,
 	genFormattingDiagnostic,
 	positionAfter,
@@ -91,11 +91,9 @@ export async function sortNodesAndProperties(
 			: [],
 	);
 
-	const newText = applyEdits(
+	const newText = applyFileDiagnosticEdits(
 		TextDocument.create(fsPath, 'devicetree', 0, text),
-		filterOnOffEdits(formatOnOffMeta, settings, t)
-			.flatMap((i) => i.raw.edit)
-			.filter((e) => !!e),
+		filterOnOffEdits(formatOnOffMeta, settings, t),
 	);
 
 	if (t.flatMap((d) => d.raw.edit).filter((e) => !!e).length) {

--- a/server/src/helpers.ts
+++ b/server/src/helpers.ts
@@ -540,7 +540,7 @@ export const genStandardTypeDiagnostic = (
 		range: toRangeWithTokenIndex(start, end),
 		severity,
 		fsPath: start.fsPath,
-		linkedTo: linkedTo.map(({ range, fsPath }, i) => {
+		linkedTo: linkedTo.map(({ range, fsPath }) => {
 			const convertedToDoc = convertVirtualFsPathToDocumentFsPath(fsPath);
 			if (convertedToDoc) {
 				return {
@@ -699,6 +699,7 @@ export function genFormattingDiagnostic(
 		templateStrings,
 		edit,
 		codeActionTitle,
+		virtual: isVirtualFsPath(fsPath),
 	};
 
 	let diagnostic: Diagnostic;
@@ -1600,6 +1601,18 @@ export function getCMacroCall(
 		return ast;
 	}
 	return getCMacroCall(ast.parentNode);
+}
+
+export function applyFileDiagnosticEdits(
+	document: TextDocument,
+	formattingIssues: FileDiagnostic[],
+): string {
+	const edits = formattingIssues
+		.filter((i) => !i.raw.virtual)
+		.flatMap((i) => i.raw.edit)
+		.filter((e) => !!e);
+
+	return applyEdits(document, edits);
 }
 
 export function applyEdits(document: TextDocument, edits: TextEdit[]): string {


### PR DESCRIPTION
Addresses Issue with formatter applying changes from virtual documents as mentioned here https://github.com/kylebonnici/dts-lsp/pull/132, https://github.com/kylebonnici/dts-lsp/issues/131 and https://github.com/kylebonnici/dts-linter/issues/9This fixes https://github.com/kylebonnici/dts-lsp/issues/131 and https://github.com/kylebonnici/dts-linter/issues/9

