### PR TITLE
Fix: idempotence violation when formatting multiline comments inside arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed Unknown syntax error with multiple elif branches.
 - Diagnostics linked to virtual documents now point to the macro that
   generated the code.
+- Fixed idempotence violation when formatting multiline comments inside arrays.
 
 ### Security
 

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -2244,7 +2244,7 @@ const formatBlockCommentLine = (
 				level,
 				indentString,
 				documentText,
-				' ',
+				getPropertyIndentPrefix(settings, levelMeta?.inAst, ' '),
 			),
 		);
 	}

--- a/server/src/test/documentFormating.test.ts
+++ b/server/src/test/documentFormating.test.ts
@@ -838,6 +838,18 @@ l1: &sdhi1 {};
 			expect(newText).toEqual('/ {\n\tprop11 = <10 /* foo */>;\n};');
 		});
 
+		test('comment in array value', async () => {
+			const documentText = `&kscan {
+	events = <
+		/* a comment inside an array that spans
+		multiple lines.*/ >;
+};`;
+			const newText = await getNewText(documentText);
+			expect(newText).toEqual(
+				`&kscan {\n\tevents = <\n\t\t\t  /* a comment inside an array that spans\n\t\t\t   * multiple lines.\n\t\t\t   */>;\n};`,
+			);
+		});
+
 		test('new line start block in line no spaces', async () => {
 			const documentText = '/*\nfoo*/';
 			const newText = await getNewText(documentText);


### PR DESCRIPTION
https://github.com/kylebonnici/dts-lsp/issues/138