### PR TITLE
Fix/multi line formatting idempotence violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   generated the code.
 - Fixed idempotence violation when formatting multiline comments inside arrays.
 - Fixed showing and applying formatting issue from virtual documents. [Contribution by [urob](https://github.com/urob)]
+- Fixed idempotence violation when formatting long lines inside disabled #if guards. [Contribution by [urob](https://github.com/urob)]
 
 ### Security
 

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -548,7 +548,7 @@ const getDisabledMarcoRangeEdits = async (
 
 			return results;
 		}),
-	].filter((v) => !!v);
+	];
 
 	const action = (meta: {
 		block: IfElIfBlock;

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -188,36 +188,24 @@ export async function formatText(
 
 	const options = convertToFormattingFlags(documentFormattingParams.options);
 
-	if (options.removeMacroMultiline) {
-		const multiLineRegions = new Set<number>();
-		Array.from(parser.cPreprocessorParser.macros.values())
-			.filter(
-				(m) =>
-					m.macro.firstToken.pos.line !== m.macro.lastToken.pos.line,
-			)
-			.forEach((m) => {
-				Array.from(
-					{
-						length:
-							m.macro.lastToken.pos.line -
-							m.macro.firstToken.pos.line +
-							1,
-					},
-					(_, i) => m.macro.firstToken.pos.line + i,
-				).forEach((line) => multiLineRegions.add(line));
-			});
-
-		// appends edits to variantDocuments
-		await formatMultiLineMacros(
-			fsPath,
-			text,
-			multiLineRegions,
-			variantDocuments,
-		);
-	}
-
 	if (returnType === 'New Text') {
 		let finalText = text;
+
+		if (options.removeMacroMultiline) {
+			finalText = await formatMultiLineMacros(
+				{
+					...documentFormattingParams,
+					options: {
+						...documentFormattingParams.options,
+						wordWrapColumn,
+					},
+				},
+				fsPath,
+				text,
+				parser,
+				returnType,
+			);
+		}
 
 		if (options.removeDuplicateProperties) {
 			let prevText = '';
@@ -377,6 +365,23 @@ export async function formatText(
 	}
 
 	let diagnostic: FileDiagnostic[] = [];
+
+	if (options.removeMacroMultiline) {
+		const r = await formatMultiLineMacros(
+			{
+				...documentFormattingParams,
+				options: {
+					...documentFormattingParams.options,
+					wordWrapColumn,
+				},
+			},
+			fsPath,
+			text,
+			parser,
+			returnType,
+		);
+		diagnostic.push(...r);
+	}
 
 	if (options.removeDuplicateProperties) {
 		const r = await removeDuplicateProperties(
@@ -596,12 +601,45 @@ const getDisabledMarcoRangeEdits = async (
 };
 
 async function formatMultiLineMacros(
+	documentFormattingParams: CustomDocumentFormattingParams,
 	fsPath: string,
 	text: string,
-	multiLineRegions: Set<number>,
-	edits: FileDiagnostic[] = [],
-) {
+	parser: Parser,
+	returnType: 'New Text',
+): Promise<string>;
+async function formatMultiLineMacros(
+	documentFormattingParams: CustomDocumentFormattingParams,
+	fsPath: string,
+	text: string,
+	parser: Parser,
+	returnType: 'File Diagnostics',
+): Promise<FileDiagnostic[]>;
+async function formatMultiLineMacros(
+	documentFormattingParams: CustomDocumentFormattingParams,
+	fsPath: string,
+	text: string,
+	parser: Parser,
+	returnType: 'File Diagnostics' | 'New Text',
+): Promise<FileDiagnostic[] | string> {
 	const splitDocument = text.split('\n');
+	const edits: FileDiagnostic[] = [];
+
+	const multiLineRegions = new Set<number>();
+	Array.from(parser.cPreprocessorParser.macros.values())
+		.filter(
+			(m) => m.macro.firstToken.pos.line !== m.macro.lastToken.pos.line,
+		)
+		.forEach((m) => {
+			Array.from(
+				{
+					length:
+						m.macro.lastToken.pos.line -
+						m.macro.firstToken.pos.line +
+						1,
+				},
+				(_, i) => m.macro.firstToken.pos.line + i,
+			).forEach((line) => multiLineRegions.add(line));
+		});
 
 	splitDocument.forEach((text, line) => {
 		if (text.trimEnd().endsWith('\\') && !multiLineRegions.has(line)) {
@@ -627,6 +665,26 @@ async function formatMultiLineMacros(
 			);
 		}
 	});
+
+	const formatOnOffMeta = pairFormatOnOff(parser.allAstItems, splitDocument);
+
+	const rangeEdits = filterOnOffEdits(
+		formatOnOffMeta,
+		documentFormattingParams,
+		edits,
+	);
+
+	const newText = applyFileDiagnosticEdits(
+		TextDocument.create(fsPath, 'devicetree', 0, text),
+		rangeEdits,
+	);
+
+	switch (returnType) {
+		case 'New Text':
+			return newText;
+		case 'File Diagnostics':
+			return edits;
+	}
 }
 
 async function formatAstBaseItems(

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -113,10 +113,9 @@ const hasLongLines = (text: string, tabSize: number, wordWrapColumn: number) =>
 		);
 
 export async function formatText(
-	documentFormattingParams: (
+	documentFormattingParams:
 		| DocumentFormattingParams
-		| DocumentRangeFormattingParams
-	) & { ranges?: Range[] },
+		| DocumentRangeFormattingParams,
 	text: string,
 	returnType: 'New Text',
 	tokens?: Token[],
@@ -124,10 +123,9 @@ export async function formatText(
 	processedPrevIfBlocks?: CIfBase[],
 ): Promise<string>;
 export async function formatText(
-	documentFormattingParams: (
+	documentFormattingParams:
 		| DocumentFormattingParams
-		| DocumentRangeFormattingParams
-	) & { ranges?: Range[] },
+		| DocumentRangeFormattingParams,
 	text: string,
 	returnType: 'File Diagnostics',
 	tokens?: Token[],
@@ -135,10 +133,9 @@ export async function formatText(
 	processedPrevIfBlocks?: CIfBase[],
 ): Promise<FileDiagnostic[]>;
 export async function formatText(
-	documentFormattingParams: (
+	documentFormattingParams:
 		| DocumentFormattingParams
-		| DocumentRangeFormattingParams
-	) & { ranges?: Range[] },
+		| DocumentRangeFormattingParams,
 	text: string,
 	returnType: 'New Text' | 'File Diagnostics',
 	tokens?: Token[],

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -54,6 +54,7 @@ import {
 	fileURIToFsPath,
 	genFormattingDiagnostic,
 	isPathEqual,
+	isRangeInRange,
 	rangesOverlap,
 	toPosition,
 	toRange,
@@ -520,14 +521,7 @@ const getDisabledMarcoRangeEdits = async (
 		(ast) => ast instanceof IfElIfBlock,
 	);
 
-	const newIfBlocks = ifBlocks.filter((b) =>
-		prevIfBlocks.every(
-			(bb) => b.firstToken.pos.line !== bb.firstToken.pos.line,
-		),
-	);
-	prevIfBlocks.push(...newIfBlocks);
-
-	const rangesToWorkOn = [
+	let rangesToWorkOn = [
 		...ifBlocks.flatMap((block) => {
 			const active = block.ifBlocks.find((i) => i.active);
 			const results: {
@@ -549,6 +543,19 @@ const getDisabledMarcoRangeEdits = async (
 			return results;
 		}),
 	];
+
+	if ('range' in documentFormattingParams) {
+		rangesToWorkOn = rangesToWorkOn.filter((d) =>
+			isRangeInRange(documentFormattingParams.range, d.block.range),
+		);
+		prevIfBlocks.push(
+			...ifBlocks.filter((b) =>
+				isRangeInRange(documentFormattingParams.range, b.range),
+			),
+		);
+	} else {
+		prevIfBlocks.push(...ifBlocks);
+	}
 
 	const action = (meta: {
 		block: IfElIfBlock;
@@ -583,17 +590,11 @@ const getDisabledMarcoRangeEdits = async (
 	};
 
 	const results: FileDiagnostic[] = [];
-	await rangesToWorkOn
-		.filter((r) =>
-			processedPrevIfBlocks.every(
-				(i) => i.firstToken.pos.line !== r.block.firstToken.pos.line,
-			),
-		)
-		.reduce((acc, curr) => {
-			return acc.then(async () => {
-				results.push(...(await action(curr)));
-			});
-		}, Promise.resolve());
+	await rangesToWorkOn.reduce((acc, curr) => {
+		return acc.then(async () => {
+			results.push(...(await action(curr)));
+		});
+	}, Promise.resolve());
 	return results;
 };
 

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -169,24 +169,92 @@ export async function formatText(
 			? documentFormattingParams.options.wordWrapColumn
 			: 100;
 
-	let variantDocuments = await getDisabledMarcoRangeEdits(
-		{
-			...documentFormattingParams,
-			options: {
-				...documentFormattingParams.options,
-				wordWrapColumn,
+	let variantDocuments: FileDiagnostic[] = [];
+	if (returnType === 'File Diagnostics') {
+		variantDocuments = await getDisabledMarcoRangeEdits(
+			{
+				...documentFormattingParams,
+				options: {
+					...documentFormattingParams.options,
+					wordWrapColumn,
+				},
 			},
-		},
-		parser,
-		prevIfBlocks,
-		processedPrevIfBlocks,
-		rawTokens,
-		text,
-	);
-	if (returnType === 'New Text' && variantDocuments.length) {
+			parser,
+			prevIfBlocks,
+			processedPrevIfBlocks,
+			rawTokens,
+			text,
+		);
+	} else if (returnType === 'New Text') {
+		const variants = [
+			{
+				removeMacroMultiline: true,
+				removeEmptyReferences: true,
+				removeDuplicateProperties: true,
+				baseFormattingRules: false,
+				wrapLongLines: false,
+				indentExpressions: false,
+			},
+			{
+				baseFormattingRules: true,
+				wrapLongLines: false,
+				indentExpressions: false,
+				removeMacroMultiline: false,
+				removeEmptyReferences: false,
+				removeEmptyNodes: false,
+				removeEmptyRoots: false,
+				removeDuplicateProperties: false,
+			},
+			{
+				wrapLongLines: true,
+				indentExpressions: false,
+				baseFormattingRules: false,
+				removeMacroMultiline: false,
+				removeEmptyReferences: false,
+				removeEmptyNodes: false,
+				removeEmptyRoots: false,
+				removeDuplicateProperties: false,
+			},
+			{
+				indentExpressions: true,
+				wrapLongLines: false,
+				baseFormattingRules: false,
+				removeMacroMultiline: false,
+				removeEmptyReferences: false,
+				removeEmptyNodes: false,
+				removeEmptyRoots: false,
+				removeDuplicateProperties: false,
+			},
+		];
+
 		const document = TextDocument.create(fsPath, 'devicetree', 0, text);
-		const newText = applyFileDiagnosticEdits(document, variantDocuments);
-		return formatText(documentFormattingParams, newText, returnType);
+
+		for (const options of variants) {
+			const variantDocuments = await getDisabledMarcoRangeEdits(
+				{
+					...documentFormattingParams,
+					options: {
+						wordWrapColumn,
+						...documentFormattingParams.options,
+						...options,
+					},
+				},
+				parser,
+				prevIfBlocks,
+				processedPrevIfBlocks,
+				rawTokens,
+				text,
+			);
+
+			if (!variantDocuments.length) continue;
+
+			const newText = applyFileDiagnosticEdits(
+				document,
+				variantDocuments,
+			);
+
+			return formatText(documentFormattingParams, newText, returnType);
+		}
 	}
 
 	const options = convertToFormattingFlags(documentFormattingParams.options);

--- a/server/src/formatting/getDocumentFormatting.ts
+++ b/server/src/formatting/getDocumentFormatting.ts
@@ -183,6 +183,11 @@ export async function formatText(
 		rawTokens,
 		text,
 	);
+	if (returnType === 'New Text' && variantDocuments.length) {
+		const document = TextDocument.create(fsPath, 'devicetree', 0, text);
+		const newText = applyFileDiagnosticEdits(document, variantDocuments);
+		return formatText(documentFormattingParams, newText, returnType);
+	}
 
 	const options = convertToFormattingFlags(documentFormattingParams.options);
 
@@ -568,6 +573,7 @@ const getDisabledMarcoRangeEdits = async (
 		const newTokenStream = rawTokens.filter((t) => !rangeToClean.has(t));
 		const range = meta.block.range;
 		processedPrevIfBlocks.push(meta.branch);
+
 		return formatText(
 			{
 				...documentFormattingParams,
@@ -575,10 +581,6 @@ const getDisabledMarcoRangeEdits = async (
 				options: {
 					...documentFormattingParams.options,
 					sortNodesAndProperties: false,
-					removeDuplicateProperties: false,
-					removeEmptyReferences: false,
-					removeEmptyNodes: false,
-					removeEmptyRoots: false,
 				},
 			},
 			text,

--- a/server/src/formatting/longLines.ts
+++ b/server/src/formatting/longLines.ts
@@ -385,7 +385,6 @@ const formatLongLinesDtcProperty = (
 
 	if (property.values) {
 		return formatLongLinesPropertyValues(
-			property,
 			property.propertyName?.name.length ?? 0,
 			property.values,
 			level,
@@ -401,7 +400,6 @@ const formatLongLinesDtcProperty = (
 };
 
 const formatLongLinesPropertyValues = (
-	property: DtcProperty,
 	propertyNameWidth: number,
 	values: PropertyValues,
 	level: number,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1983,10 +1983,8 @@ connection.onRequest(
 
 		const textAfterEdits = applyEdits(document, event.edits);
 
-		let formatRanges: Range[] | undefined;
-
 		const newText = await formatText(
-			{ ...event, ranges: formatRanges },
+			{ ...event },
 			textAfterEdits,
 			'New Text',
 		).catch(() => textAfterEdits);

--- a/server/src/test/documentFormating.test.ts
+++ b/server/src/test/documentFormating.test.ts
@@ -862,7 +862,7 @@ l1: &sdhi1 {};
 };`;
 			const newText = await getNewText(documentText);
 			expect(newText).toEqual(
-				`/ {\n\tkeymap {\n#ifdef ANSI\n\t\tdefault_layer {\n\t\t\tbindings = <&kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 kp MINUS\n\t\t\t\t\t\t&kp EQUAL &kp BSPC &kp TAB &kp Q &kp W &kp E &kp R &kp T &kp Y &kp U &kp I &kp O &kp P &kp LBKT &kp\n\t\t\t\t\t\tRBKT &kp BSLH>;\n\t\t};\n#endif\n\t};\n};`,
+				`/ {\n\tkeymap {\n#ifdef ANSI\n\t\tdefault_layer {\n\t\t\tbindings = <&kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp\n\t\t\t\t\t\tN0 kp MINUS &kp EQUAL &kp BSPC &kp TAB &kp Q &kp W &kp E &kp R &kp T &kp Y\n\t\t\t\t\t\t&kp U &kp I &kp O &kp P &kp LBKT &kp RBKT &kp BSLH>;\n\t\t};\n#endif\n\t};\n};`,
 			);
 		});
 

--- a/server/src/test/documentFormating.test.ts
+++ b/server/src/test/documentFormating.test.ts
@@ -850,7 +850,7 @@ l1: &sdhi1 {};
 			);
 		});
 
-		test('comment in array value', async () => {
+		test('wrap long, tab size 4 in #if guard', async () => {
 			const documentText = `/ {
   keymap {
 #ifdef ANSI

--- a/server/src/test/documentFormating.test.ts
+++ b/server/src/test/documentFormating.test.ts
@@ -850,6 +850,22 @@ l1: &sdhi1 {};
 			);
 		});
 
+		test('comment in array value', async () => {
+			const documentText = `/ {
+  keymap {
+#ifdef ANSI
+    default_layer {
+      bindings = <&kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 kp MINUS &kp EQUAL &kp BSPC   &kp TAB &kp Q &kp W &kp E &kp R &kp T &kp Y &kp U &kp I &kp O &kp P &kp LBKT &kp RBKT &kp BSLH>;
+    };
+#endif
+  };
+};`;
+			const newText = await getNewText(documentText);
+			expect(newText).toEqual(
+				`/ {\n\tkeymap {\n#ifdef ANSI\n\t\tdefault_layer {\n\t\t\tbindings = <&kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 kp MINUS\n\t\t\t\t\t\t&kp EQUAL &kp BSPC &kp TAB &kp Q &kp W &kp E &kp R &kp T &kp Y &kp U &kp I &kp O &kp P &kp LBKT &kp\n\t\t\t\t\t\tRBKT &kp BSLH>;\n\t\t};\n#endif\n\t};\n};`,
+			);
+		});
+
 		test('new line start block in line no spaces', async () => {
 			const documentText = '/*\nfoo*/';
 			const newText = await getNewText(documentText);


### PR DESCRIPTION
Fix https://github.com/kylebonnici/dts-lsp/issues/142

When formatting some steps like formatting lines other steps are needed as a precursors. Formatting disabled macro manipulates the document in a way to force all #if guards to be come active individually. Give that we need to format the range of the disabled macro in full i.e. apply all precursors multiple iteration are needed.

This PR abstract the idempotence issue by re running the formatting on that section until all contains are satisfied