### PR TITLE
Fix default lock rename edits typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
 					"scope": "resource",
 					"type": "array",
 					"default": null,
-					"description": "Locations that Renaming should not be allowrd if any of the edits is a child node of that directory"
+					"description": "Locations that Renaming should not be allowed if any of the edits is a child node of that directory"
 				},
 				"devicetree.allowAdhocContexts": {
 					"scope": "resource",


### PR DESCRIPTION
## Summary
- Fix the `allowrd` typo in the `devicetree.defaultLockRenameEdits` package description.

## Validation
- `rg -n 'allowrd|allowed|defaultLockRenameEdits|Renaming' package.json`
- `node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); console.log("package.json parses")'`
- `git diff --check`

Resolves #156.