### PR TITLE
Fix: respect required when used with default for zephyr bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Avoid binding validation diagnostics for nodes with `/omit-if-no-ref/` that are not referenced.
+- Fixed `required` not being respected when using Zephyr bindings with a `default` value defined.
 
 ## [0.11.0] - 2026-08-01
 

--- a/server/src/context/node.ts
+++ b/server/src/context/node.ts
@@ -562,6 +562,7 @@ export class Node {
 		const defProps = (this.nodeType?.defaultProperties ?? []).filter(
 			(p) =>
 				!this.getProperty(p.name) &&
+				!p.required &&
 				p.name !== '#address-cells' &&
 				p.name !== '#size-cells' &&
 				p.name !== 'status',


### PR DESCRIPTION
Aligns with expectation defined here https://github.com/zephyrproject-rtos/zephyr/pull/115576